### PR TITLE
Optimize VRAM usage for multiview inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ ckpt
 result
 **/__pycache__/
 **/.DS_Store
+venv
+nvdiffrast
+*.whl

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ python infer_canonicalize.py --input_dir ./input_cases --output_dir ./result/apo
 # stage 1.2: A-pose image to multi-view image
 # decomposed generation (by default)
 python infer_multiview.py --input_dir ./result/apose --output_dir ./result/multiview
+# with model offloading to save VRAM (may be slower)
+python infer_multiview.py --input_dir ./result/apose --output_dir ./result/multiview --low_vram
 # If you only need non-decomposed generation, then run:
 python infer_multiview.py --input_dir ./result/apose --output_dir ./result/multiview --num_levels 1
 

--- a/infer_multiview.py
+++ b/infer_multiview.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from dataclasses import dataclass
 from typing import Dict
 import torch
-import torch.nn.functional as F
 import torch.utils.checkpoint
 import torchvision.transforms.functional as TF
 from torch.utils.data import Dataset, DataLoader
@@ -167,7 +166,7 @@ def run_multiview_infer(dataloader, pipeline, cfg: TestConfig, save_dir, num_lev
     if cfg.seed is None:
         generator = None
     else:
-        generator = torch.Generator(device=pipeline.unet.device).manual_seed(cfg.seed)
+        generator = torch.Generator(device="cuda" if torch.cuda.is_available else "cpu").manual_seed(cfg.seed)
     
     images_cond = []
     for _, batch in tqdm(enumerate(dataloader)):
@@ -229,6 +228,8 @@ def load_multiview_pipeline(cfg):
     pipeline.unet.enable_xformers_memory_efficient_attention()
     if torch.cuda.is_available():
         pipeline.to(device)
+        pipeline.enable_model_cpu_offload()
+        pipeline.enable_vae_slicing()
     return pipeline
 
 def main(
@@ -247,7 +248,7 @@ def main(
     image_transforms = transforms.Compose(image_transforms)
     dataset = SingleImageData(image_transforms=image_transforms, input_dir=cfg.input_dir, total_views=cfg.num_views)
     dataloader = torch.utils.data.DataLoader(
-        dataset, batch_size=1, shuffle=False, num_workers=1
+        dataset, batch_size=1, shuffle=False
     )
     os.makedirs(cfg.output_dir, exist_ok=True)
 

--- a/infer_multiview.py
+++ b/infer_multiview.py
@@ -228,8 +228,10 @@ def load_multiview_pipeline(cfg):
     pipeline.unet.enable_xformers_memory_efficient_attention()
     if torch.cuda.is_available():
         pipeline.to(device)
-        pipeline.enable_model_cpu_offload()
-        pipeline.enable_vae_slicing()
+        if cfg.low_vram:
+            print("Using Model CPU Offload and VAE Slicing to save VRAM Usage.")
+            pipeline.enable_model_cpu_offload()
+            pipeline.enable_vae_slicing()
     return pipeline
 
 def main(
@@ -266,6 +268,7 @@ if __name__ == '__main__':
     parser.add_argument("--width", type=int, default=576)
     parser.add_argument("--input_dir", type=str, default='./result/apose')
     parser.add_argument("--output_dir", type=str, default='./result/multiview')
+    parser.add_argument("--low_vram", action='store_true')
     cfg = parser.parse_args()
 
     if cfg.num_views == 6:

--- a/multiview/pipeline_multiclass.py
+++ b/multiview/pipeline_multiclass.py
@@ -107,6 +107,7 @@ class StableUnCLIPImg2ImgPipeline(DiffusionPipeline):
         self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1)
         self.image_processor = VaeImageProcessor(vae_scale_factor=self.vae_scale_factor)
         self.num_views: int = num_views
+        self.model_cpu_offload_seq = "text_encoder->image_encoder->image_normalizer->vae->unet->vae"
     # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline.enable_vae_slicing
     def enable_vae_slicing(self):
         r"""


### PR DESCRIPTION
Implements `enable_model_cpu_offload` for the pipeline and added flags to control cpu offloading and vae slicing.